### PR TITLE
feat: check null for empty string match

### DIFF
--- a/jsonquery-querydsl-base/src/main/java/com/lindar/jsonquery/querydsl/QuerydslJsonQueryVisitor.java
+++ b/jsonquery-querydsl-base/src/main/java/com/lindar/jsonquery/querydsl/QuerydslJsonQueryVisitor.java
@@ -60,7 +60,7 @@ public abstract class QuerydslJsonQueryVisitor implements JsonQueryVisitor<Predi
                 predicate = stringPath.like("%"+singleValue);
                 break;
             case EMPTY:
-                predicate = stringPath.eq("");
+                predicate = stringPath.eq("").or(stringPath.isNull());
                 break;
             case IN:
                 predicate = stringPath.in(node.getValue());

--- a/jsonquery-querydsl-jpa/src/test/java/com/lindar/jsonquery/querydsl/jpa/TestQuerydslJpaJsonQueryVisitor.java
+++ b/jsonquery-querydsl-jpa/src/test/java/com/lindar/jsonquery/querydsl/jpa/TestQuerydslJpaJsonQueryVisitor.java
@@ -318,7 +318,7 @@ public class TestQuerydslJpaJsonQueryVisitor {
                         StringComparisonOperation.CONTAINS,
                         value));
 
-        assertToString("player.promocode = ?1",
+        assertToString("player.promocode = ?1 or player.promocode is null",
                 createStringComparisonNodePredicate("promocode",
                         StringComparisonOperation.EMPTY,
                         value));

--- a/jsonquery-querydsl-jpa/src/test/java/com/lindar/jsonquery/querydsl/jpa/TestQuerydslJpaJsonQueryVisitor.java
+++ b/jsonquery-querydsl-jpa/src/test/java/com/lindar/jsonquery/querydsl/jpa/TestQuerydslJpaJsonQueryVisitor.java
@@ -350,6 +350,31 @@ public class TestQuerydslJpaJsonQueryVisitor {
     }
 
     @Test
+    public void testStringEmptyComparisonPutsEmptyAndNullInBrackets() {
+        StringComparisonNode empty = new StringComparisonNode();
+        empty.setField("promocode");
+        empty.setOperation(StringComparisonOperation.EMPTY);
+
+        StringComparisonNode equal = new StringComparisonNode();
+        equal.setField("nationality");
+        equal.setOperation(StringComparisonOperation.EQUALS);
+        equal.setValue(Lists.newArrayList("POL"));
+
+
+        JsonQuery holder = new JsonQuery();
+        holder.getConditions().getItems().add(empty);
+        holder.getConditions().getItems().add(equal);
+
+        JPAQuery query = new JPAQuery();
+        PathBuilder entity = new PathBuilder(Player.class, "player");
+        BooleanBuilder booleanBuilder = new BooleanBuilder();
+        QuerydslJpaJsonQuery.applyPredicateAsSubquery(booleanBuilder, entity, holder);
+
+        query.select(entity).from(entity).where(booleanBuilder);
+        assertToString("(select player from Player player where player in (select player from Player player where (player.promocode = ?1 or player.promocode is null) and player.nationality = ?2))", query);
+    }
+
+    @Test
     public void testVisitBigDecimalComparisonNode() {
         List<BigDecimal> value = Lists.newArrayList(BigDecimal.ZERO);
         List<BigDecimal> values = Lists.newArrayList(BigDecimal.ZERO, BigDecimal.TEN);

--- a/jsonquery-querydsl-sql/src/test/java/com/lindar/jsonquery/querydsl/sql/TestQuerydslJqlJsonQueryVisitor.java
+++ b/jsonquery-querydsl-sql/src/test/java/com/lindar/jsonquery/querydsl/sql/TestQuerydslJqlJsonQueryVisitor.java
@@ -324,7 +324,7 @@ public class TestQuerydslJqlJsonQueryVisitor {
                 StringComparisonOperation.CONTAINS,
                 value));
 
-        assertToString("player.promocode = ",
+        assertToString("player.promocode =  || player.promocode is null",
             createStringComparisonNodePredicate("promocode",
                 StringComparisonOperation.EMPTY,
                 value));


### PR DESCRIPTION
We've discovered EMPTY checks on string fields do not take null values into account. Where for enum, number and other null check is done. 

This change improves the empty check for strings to also check with `.isNull()`

**Testing**
With automated tests and on a dynamic environment